### PR TITLE
Added a default maximum bitrate when creating a room

### DIFF
--- a/src/v4/social/features/livestream/internal-components/LivestreamStage/StreamerStage/StreamerStage.tsx
+++ b/src/v4/social/features/livestream/internal-components/LivestreamStage/StreamerStage/StreamerStage.tsx
@@ -378,7 +378,14 @@ export const StreamerStage: FC<StreamerStageProps> = ({
   const { channel: liveChannel } = useChannel({ channelId: channel?.channelId });
   const { success } = useNotifications();
   const { moderateChat } = useChatModeration();
-  const [liveKitRoom] = useState(new Room());
+  const [liveKitRoom] = useState(new Room({
+    videoCaptureDefaults: {
+      resolution: { width: 1280, height: 720, frameRate: 30 },
+    },
+    publishDefaults: {
+      videoEncoding: { maxBitrate: 5_000_000, maxFramerate: 30 },
+    },
+  }));
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
Eko link: https://ekogreen.ekoapp.com/recents/group/66fe7b1b8c03f40d8cde4471/t/670664a110ffec45bd94f157
SLE ticket:
https://socialplus.atlassian.net/browse/SLE-310

Set a default maximum bitrate when creating a room, as the current maximum (2.5 MB) impacts livestream quality.